### PR TITLE
Fix NullReferenceException

### DIFF
--- a/WiseUnpacker/Files/MultiPartFile.cs
+++ b/WiseUnpacker/Files/MultiPartFile.cs
@@ -130,7 +130,8 @@ namespace WiseUnpacker.Files
         {
             int bufpos;
 
-            MultiPartFile mf = this;
+            MultiPartFile? mf = this;
+
             while (Position > mf._partEnd && mf._next != null)
             {
                 mf = mf._next;
@@ -147,16 +148,21 @@ namespace WiseUnpacker.Files
             }
             else
             {
-                byte[] buf = new byte[0xffff];
+                byte[] buf = new byte[count];
                 bufpos = 0;
                 do
                 {
+                    if (mf == null)
+                    {
+                        break;
+                    }
+
                     if (mf!._partEnd + 1 < Position + count - bufpos)
                     {
                         mf._stream.Read(buf, bufpos, (int)(mf._partEnd + 1 - Position));
                         bufpos += (int)(mf._partEnd + 1 - Position);
                         Position = mf._partEnd + 1;
-                        mf = mf._next!;
+                        mf = mf._next;
                     }
                     else
                     {
@@ -167,7 +173,7 @@ namespace WiseUnpacker.Files
                 }
                 while (bufpos != count);
 
-                Array.ConstrainedCopy(buf, 0, buffer, offset, count);
+                Array.ConstrainedCopy(buf, 0, buffer, offset, bufpos);
             }
 
             return count;

--- a/WiseUnpacker/Files/MultiPartFile.cs
+++ b/WiseUnpacker/Files/MultiPartFile.cs
@@ -153,9 +153,7 @@ namespace WiseUnpacker.Files
                 do
                 {
                     if (mf == null)
-                    {
                         break;
-                    }
 
                     if (mf!._partEnd + 1 < Position + count - bufpos)
                     {

--- a/WiseUnpacker/Files/MultiPartFile.cs
+++ b/WiseUnpacker/Files/MultiPartFile.cs
@@ -137,7 +137,7 @@ namespace WiseUnpacker.Files
                 mf = mf._next;
             }
 
-            if (Position > mf._partEnd)
+            if (mf == null || Position > mf._partEnd)
                 return 0;
 
             mf._stream.Seek(Position - mf._partStart, SeekOrigin.Begin);

--- a/WiseUnpacker/Inflation/InflateImpl.cs
+++ b/WiseUnpacker/Inflation/InflateImpl.cs
@@ -53,7 +53,7 @@ namespace WiseUnpacker.Inflation
         {
             if (_inputBufferPosition >= _inputBufferSize)
             {
-                if (_inputFile.Position == _inputFile.Length)
+                if (_inputFile.Position >= _inputFile.Length)
                 {
                     SI_BREAK = true;
                     return Byte.MaxValue;


### PR DESCRIPTION
Fix NullReferenceException that occurred when attempting to use WiseUnpacker with an Installshield archive, along with other minor fixes. 